### PR TITLE
Fix/wrong validations and unnecessary escaping on user fields

### DIFF
--- a/src/middlewares/validators/user.js
+++ b/src/middlewares/validators/user.js
@@ -1,0 +1,107 @@
+import { body } from "express-validator";
+import * as errors from "../../validation/errors/models";
+
+const store = () => [
+  body("nickname")
+    .notEmpty()
+    .withMessage(errors.nickname.empty)
+    .bail()
+    .isLength({ min: 0, max: 20 })
+    .withMessage(errors.nickname.invalidLength)
+    .escape(),
+  body("birthdate")
+    .notEmpty()
+    .withMessage(errors.birthdate.empty)
+    .bail()
+    .isDate()
+    .withMessage(errors.birthdate.nonDate)
+    .escape(),
+  body("isAdmin")
+    .optional()
+    .isBoolean()
+    .withMessage(errors.isAdmin.nonBoolean)
+    .bail()
+    .escape(),
+  body("selectedAvatar")
+    .optional()
+    .notEmpty()
+    .withMessage(errors.selectedAvatar.empty)
+    .bail()
+    .escape(),
+  body("password")
+    .notEmpty()
+    .withMessage(errors.password.empty)
+    .bail()
+    .isLength({ min: 6, max: 50 })
+    .withMessage(errors.password.invalidLength)
+    .escape(),
+  body("xp")
+    .optional()
+    .notEmpty()
+    .withMessage(errors.xp.empty)
+    .bail()
+    .isInt()
+    .withMessage(errors.xp.nonInteger)
+    .escape(),
+];
+
+const update = () => [
+  [
+    body("nickname")
+      .optional()
+      .notEmpty()
+      .withMessage(errors.nickname.empty)
+      .bail()
+      .isLength({ min: 0, max: 20 })
+      .withMessage(errors.nickname.invalidLength)
+      .escape(),
+  ],
+  [
+    body("birthdate")
+      .optional()
+      .notEmpty()
+      .withMessage(errors.birthdate.empty)
+      .bail()
+      .isDate()
+      .withMessage(errors.birthdate.nonDate)
+      .escape(),
+  ],
+  [
+    body("isAdmin")
+      .optional()
+      .isBoolean()
+      .withMessage(errors.isAdmin.nonBoolean)
+      .bail()
+      .escape(),
+  ],
+  [
+    body("selectedAvatar")
+      .optional()
+      .notEmpty()
+      .withMessage(errors.selectedAvatar.empty)
+      .bail()
+      .escape(),
+  ],
+  [
+    body("password")
+      .optional()
+      .notEmpty()
+      .withMessage(errors.password.empty)
+      .bail()
+      .isLength({ min: 6, max: 50 })
+      .withMessage(errors.password.invalidLength)
+      .escape(),
+  ],
+  [
+    body("xp")
+      .optional()
+      .notEmpty()
+      .withMessage(errors.xp.empty)
+      .bail()
+      .isInt()
+      .withMessage(errors.xp.nonInteger)
+      .escape(),
+  ],
+];
+
+export default { store, update };

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -13,7 +13,7 @@ const fieldsValidation = [
   // FOR UPDATE, MAKE AN EQUAL VALIDATION MIDDLEWARES ARRAY BUT WITH ALL FIELDS AS OPTIONAL
   [
     body("nickname")
-      .notEmpty()
+      .exists()
       .withMessage(errors.nickname.empty)
       .bail()
       .isLength({ min: 0, max: 20 })
@@ -22,10 +22,10 @@ const fieldsValidation = [
   ],
   [
     body("birthdate")
-      .notEmpty()
+      .exists()
       .withMessage(errors.birthdate.empty)
       .bail()
-      .isDate()
+      .isISO8601("yyyy-mm-dd")
       .withMessage(errors.birthdate.nonDate)
       .escape(),
   ],
@@ -34,35 +34,31 @@ const fieldsValidation = [
       .optional()
       .isBoolean()
       .withMessage(errors.isAdmin.nonBoolean)
-      .bail()
-      .escape(),
+      .bail(),
   ],
   [
     body("selectedAvatar")
       .optional()
-      .notEmpty()
+      .exists()
       .withMessage(errors.selectedAvatar.empty)
-      .bail()
-      .escape(),
+      .bail(),
   ],
   [
     body("password")
-      .notEmpty()
+      .exists()
       .withMessage(errors.password.empty)
       .bail()
       .isLength({ min: 6, max: 50 })
-      .withMessage(errors.password.invalidLength)
-      .escape(),
+      .withMessage(errors.password.invalidLength),
   ],
   [
     body("xp")
       .optional()
-      .notEmpty()
+      .exists()
       .withMessage(errors.xp.empty)
       .bail()
       .isInt()
-      .withMessage(errors.xp.nonInteger)
-      .escape(),
+      .withMessage(errors.xp.nonInteger),
   ],
 ];
 


### PR DESCRIPTION
updates to the validation and escaping rules for user fields in the application.

The first part of the merge addresses issues with the validation rules and unnecessary escaping on user fields. It updates the validation rule for checking if a field has been sent in a request to ‘exists’, and .isISO8601 is applied instead of .Date, since it wasn't identifying a string date in the format ‘YYYY-MM-DD’. ‘escape’ is unnecessary for fields that are not intended to be output in the browser, so those which agree with this have been removed.

The second part of the merge focuses on fixing the issue of allowing empty fields in the user model due to default values being set as empty strings. With the ‘exists’ validation rule, which checks for undefined values, nicknames as empty strings were being allowed when ‘nickname’ was not sent, as it would get the defaultValue. To avoid this, the defaultValues of empty strings have been removed from user fields, ensuring that all user fields are properly validated and do not default to empty strings.