### PR TITLE
refactor: simplify create_db_dev script

### DIFF
--- a/src/database/scripts/refresh_db_dev.sh
+++ b/src/database/scripts/refresh_db_dev.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+while true; do
+  read -p "Do you wish to refresh the database? (y/n) " yn
+  case $yn in
+    [Yy]* ) break;;
+    [Nn]* ) exit;;
+    * ) echo "Please answer 'yes' or 'no'.";;
+  esac
+done
+
+cd ../../../
+
+npx sequelize-cli db:migrate:undo:all
+
+echo -e "\nCreating tables..."
+
+npx sequelize-cli db:migrate
+
+echo "Inserting mock data..."
+
+npx sequelize-cli db:seed:all
+
+sleep 3


### PR DESCRIPTION
like 'php artisan migrate:refresh --seed', sequelize-cli can provide the same result on executing three instructions sequentially, so a script focused on refreshing the database - that is, reverting the migrations, applying them again and executing seeds - have been created.